### PR TITLE
[0.81] `currentActivity` -> `getCurrentActivity()`

### DIFF
--- a/android/src/main/kotlin/com/scandit/datacapture/reactnative/barcode/ScanditDataCaptureBarcodeBatchModule.kt
+++ b/android/src/main/kotlin/com/scandit/datacapture/reactnative/barcode/ScanditDataCaptureBarcodeBatchModule.kt
@@ -119,7 +119,7 @@ class ScanditDataCaptureBarcodeBatchModule(
         val view = readableMap.getString("viewJson")
         val trackedBarcodeId = readableMap.getInt("trackedBarcodeIdentifier")
 
-        currentActivity?.let {
+        getCurrentActivity()?.let {
             it.runOnUiThread {
                 val reactView = nativeViewFromJson(it, view)
 
@@ -151,7 +151,7 @@ class ScanditDataCaptureBarcodeBatchModule(
             promise.reject(Error("View for tracked barcode $trackedBarcodeId not found."))
             return
         }
-        currentActivity?.let { context ->
+        getCurrentActivity()?.let { context ->
             context.runOnUiThread {
                 cachedView.animateSizeTo(width.pxFromDp(), height.pxFromDp())
                 promise.resolve(null)


### PR DESCRIPTION
Hey,
It's Nicola here from the React Native team at Meta,

This change is necessary because of a Kotlin migration we landed inside React Native 0.81.
You would have to change those accessors to make sure this library works with 0.81.